### PR TITLE
Re-implemented private server support

### DIFF
--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -123,6 +123,7 @@ module.exports = class Multimeter extends EventEmitter {
   run() {
     this.api = new ScreepsAPI({
       token: this.config.token,
+      url: this.config.url
     });
 
     this.screen = blessed.screen({


### PR DESCRIPTION
Private server support re-implemented for the new api version (should be 1.6.x compatible for future updates), when url in settings is not set, it will default to screeps.com as normal