### PR TITLE
Logging plugin

### DIFF
--- a/plugins/log.js
+++ b/plugins/log.js
@@ -1,37 +1,33 @@
-const fs = require('fs');
-const logFile = fs.createWriteStream('screeps.log', {flags : 'a'});
-const errorLogFile = fs.createWriteStream('screeps.errors.log', {flags : 'a'});
+const fs = require("fs");
+const logFile = fs.createWriteStream("screeps.log", { flags: "a" });
+const errorLogFile = fs.createWriteStream("screeps.errors.log", { flags: "a" });
 
 module.exports = function(multimeter) {
+  let enabled = false;
 
-    let enabled = false;
-
-    function toggleLogging()
-    {
-	    if(!enabled) {
-            enabled = true;
-	        multimeter.log('Enabled logging');
-        }
-	    else {
-	        enabled = false;
-    	    multimeter.log('Disabled loggin');
-	    }
+  function toggleLogging() {
+    if (!enabled) {
+      enabled = true;
+      multimeter.log("Enabled logging");
+    } else {
+      enabled = false;
+      multimeter.log("Disabled loggin");
     }
+  }
 
-    multimeter.console.on('addLines', function(event) {
-        if(!enabled) return;
-        const msg = new Date().toISOString() + ': ' + event.line + '\n';
-        if (event.type === 'log') {
-	        logFile.write(msg);
-        }
-        else if(event.type === 'error') {
-	        errorLogFile.write(msg);
-        }
-    });
+  multimeter.console.on("addLines", function(event) {
+    if (!enabled) return;
+    const msg = new Date().toISOString() + ": " + event.line + "\n";
+    if (event.type === "log") {
+      logFile.write(msg);
+    } else if (event.type === "error") {
+      errorLogFile.write(msg);
+    }
+  });
 
-    multimeter.addCommand("log", {
-        description: "Log all console entries to a log file",
-        helpText: "Enable/Disable logging to txt file",
-        handler: toggleLogging,
-    });
+  multimeter.addCommand("log", {
+    description: "Log all console entries to a log file",
+    helpText: "Enable/Disable logging to txt file",
+    handler: toggleLogging,
+  });
 };

--- a/plugins/log.js
+++ b/plugins/log.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const logFile = fs.createWriteStream('screeps.log', {flags : 'a'});
+const errorLogFile = fs.createWriteStream('screeps.errors.log', {flags : 'a'});
+
+module.exports = function(multimeter) {
+
+    let enabled = false;
+
+    function toggleLogging()
+    {
+	    if(!enabled) {
+            enabled = true;
+	        multimeter.log('Enabled logging');
+        }
+	    else {
+	        enabled = false;
+    	    multimeter.log('Disabled loggin');
+	    }
+    }
+
+    multimeter.console.on('addLines', function(event) {
+        if(!enabled) return;
+        const msg = new Date().toISOString() + ': ' + event.line + '\n';
+        if (event.type === 'log') {
+	        logFile.write(msg);
+        }
+        else if(event.type === 'error') {
+	        errorLogFile.write(msg);
+        }
+    });
+
+    multimeter.addCommand("log", {
+        description: "Log all console entries to a log file",
+        helpText: "Enable/Disable logging to txt file",
+        handler: toggleLogging,
+    });
+};

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -16,6 +16,7 @@ const BUILTIN_PLUGINS = [
   "../plugins/watch",
   "../plugins/screeps_console.compat",
   "../plugins/html.js",
+  "../plugins/log"
 ];
 
 class Gauges extends blessed.layout {


### PR DESCRIPTION
A plugin to save the console log lines to a file.
Errors are stored in a separate file.
Enable or disable with `/log`