### PR TITLE
Enable full set of unicode characters

### DIFF
--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -138,6 +138,7 @@ module.exports = class Multimeter extends EventEmitter {
     this.api = new ScreepsAPI(opts);
 
     this.screen = blessed.screen({
+      fullUnicode: true,
       smartCSR: true,
       title: "Screeps",
     });


### PR DESCRIPTION
Enable the full set of unicode characters by setting `fullUnicode: true` in the properties for the Blessed Screen.

I've verified this enables the display of 测试 (test) in the console log. Prior to change this displayed as "??".

[Screen options](https://www.npmjs.com/package/blessed#screen-from-node)
> fullUnicode - Allow for rendering of East Asian double-width characters, utf-16 surrogate pairs, and unicode combining characters. This allows you to display text above the basic multilingual plane. This is behind an option because it may affect performance slightly negatively. Without this option enabled, all double-width, surrogate pair, and combining characters will be replaced by '??', '?', '' respectively. (NOTE: iTerm2 cannot display combining characters properly. Blessed simply removes them from an element's content if iTerm2 is detected).

Fixes #18 