### PR TITLE
Save log lines from output stream to screeps.log log file.

### DIFF
--- a/src/console.js
+++ b/src/console.js
@@ -1,5 +1,6 @@
 const blessed = require("blessed");
 const text_prompt = require("./text_prompt");
+const fs = require('fs');
 
 module.exports = class Console extends blessed.element {
   constructor(opts) {
@@ -10,7 +11,7 @@ module.exports = class Console extends blessed.element {
       left: 0,
       bottom: 1,
       scrollback: 5000,
-      tags: true,
+      tags: true
     });
 
     this.inputView = new text_prompt({
@@ -40,6 +41,10 @@ module.exports = class Console extends blessed.element {
     });
 
     this.inputView.on("line", l => this.emit("line", l));
+    
+    if (opts.logFile) {
+      this.logStream = fs.createWriteStream(opts.logFile, {flags:'a'});
+    }
   }
 
   handleComplete(line) {
@@ -58,6 +63,9 @@ module.exports = class Console extends blessed.element {
     let event = { type, line };
     this.emit("addLines", event);
     line = event.line || line;
+    if (this.logStream) {
+      this.logStream.write(line + "\n");
+    }
     line = line.split("\n").join("\n    ");
     if (event.skip) {
       return;

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -166,6 +166,7 @@ module.exports = class Multimeter extends EventEmitter {
       right: 0,
       bottom: 0,
       historyFile: ".screeps-multimeter.history",
+      logFile: "screeps.log"
     });
 
     this.console.focus();


### PR DESCRIPTION
Tested locally, useful for saving & searching historical logs.