### PR TITLE
Fix error message when watch-client.js is not installed

### DIFF
--- a/plugins/watch.js
+++ b/plugins/watch.js
@@ -37,11 +37,11 @@ module.exports = function(multimeter) {
     return multimeter.api.memory
       .get("watch")
       .then(val => {
-        if (typeof val === "object" && val.ok === 1 && typeof val.data.expressions == "object") {
+        if (val && val.ok === 1 && val.data && val.data.expressions) {
           client_verified = true;
           return val.data.expressions;
         } else {
-          throw new Error("watch-client.js is not installed or out of date.");
+          multimeter.log('Watch plugin disabled: watch-client.js is not installed or out of date.');
         }
       })
       .then(expressions => {


### PR DESCRIPTION
Fix TypeError, remove unnecessary stack trace.

Change this:

```
*** Cannot watch: TypeError: Cannot read property 'expressions' of undefined                                                          
        at multimeter.api.memory.get.then.val (/home/simon/screeps/node_modules/screeps-multimeter/plugins/watch.js:40:72)            
        at process._tickCallback (internal/process/next_tick.js:68:7)
```

To this:

```
*** Watch plugin disabled: watch-client.js is not installed or out of date.
```

To be honest, the watch plugin should be disabled by default to prevent this message completely. As a policy any plugin that requires additional setup should be opt-in only - it should **not** be in the default plugins list.