### PR TITLE
Show which shard log messages are coming from

### DIFF
--- a/src/console.js
+++ b/src/console.js
@@ -54,10 +54,13 @@ module.exports = class Console extends blessed.element {
     this.inputView.focus();
   }
 
-  addLines(type, line) {
-    let event = { type, line };
+  addLines(type, line, shard) {
+    let event = { type, line, shard };
     this.emit("addLines", event);
     line = event.line || line;
+    if (shard) {
+        line = "{grey-fg}" + shard + "{/} " + line;
+    }
     line = line.split("\n").join("\n    ");
     if (event.skip) {
       return;

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -196,7 +196,7 @@ module.exports = class Multimeter extends EventEmitter {
       this.api.socket.subscribe("console", event => {
         const { data } = event;
         if (data.messages) {
-          data.messages.log.forEach(l => this.console.addLines("log", l));
+          data.messages.log.forEach(l => this.console.addLines("log", l, data.shard));
           data.messages.results.forEach(l =>
             this.console.addLines("result", l),
           );


### PR DESCRIPTION
Similar to the screeps web console, prefix each log message with the shard name (in dark grey so it's subtle) so that you can actually see which shard each message is coming from.