### PR TITLE
Add /pause and /unpause commands

### DIFF
--- a/plugins/filter.js
+++ b/plugins/filter.js
@@ -1,0 +1,43 @@
+const blessed = require("blessed");
+
+const HELP_TEXT =
+  "/filter [string]  Filter out console messages unless they contain the string.\n" +
+  "/filter           Disable filtering.";
+
+module.exports = function(multimeter) {
+  let filterString = null;
+  let filterCount = 0;
+
+  multimeter.console.on("addLines", function(event) {
+    if (filterString && event.type == "log") {
+      let line = event.shard + ' ' + event.line;
+      if (! line.includes(filterString)) {
+        event.skip = true;
+        filterCount++;
+        multimeter.updateStatus();
+      }
+    }
+  });
+
+  multimeter.addStatus(function () {
+    if (filterString) {
+      return 'FILTERED ' + filterCount;
+    }
+  });
+
+  function commandFilter(args) {
+    if (args.length == 0) {
+      filterString = null;
+    } else {
+      filterString = args.join(' ');
+      filterCount = 0;
+    }
+    multimeter.updateStatus();
+  }
+
+  multimeter.addCommand("filter", {
+    description: "Filter the console output.",
+    helpText: HELP_TEXT,
+    handler: commandFilter,
+  });
+};

--- a/plugins/pause.js
+++ b/plugins/pause.js
@@ -1,0 +1,48 @@
+const blessed = require("blessed");
+
+const HELP_TEXT =
+  "/pause   Pause the console output.\n" +
+  "/unpause Resume the console output.";
+
+module.exports = function(multimeter) {
+  let paused = false;
+
+  multimeter.console.on("addLines", function(event) {
+    if (paused && event.type == "log") {
+      event.skip = true;
+    }
+  });
+
+  let pausedMessage = blessed.box({
+    parent: multimeter.screen,
+    bottom: 1,
+    height: 1,
+    left: "center",
+    align: "center",
+    width: 20,
+    content: "***** PAUSED *****",
+    bold: true,
+    hidden: true,
+  });
+
+  function commandPause() {
+    paused = true;
+    pausedMessage.show();
+  }
+
+  function commandUnpause() {
+    paused = false;
+    pausedMessage.hide();
+  }
+
+  multimeter.addCommand("pause", {
+    description: "Pause the console output.",
+    helpText: HELP_TEXT,
+    handler: commandPause,
+  });
+  multimeter.addCommand("unpause", {
+    description: "Resume the console output.",
+    helpText: HELP_TEXT,
+    handler: commandUnpause,
+  });
+};

--- a/plugins/pause.js
+++ b/plugins/pause.js
@@ -1,6 +1,7 @@
 const HELP_TEXT =
   "/pause   Pause the console output.\n" +
-  "/unpause Resume the console output.";
+  "/unpause Resume the console output.\n" +
+  "You can also use the F9 key to pause/unpause";
 
 module.exports = function(multimeter) {
   let paused = false;
@@ -9,6 +10,11 @@ module.exports = function(multimeter) {
     if (paused && event.type == "log") {
       event.skip = true;
     }
+  });
+
+  // Unfortunately we can't capture the pause/break key in a console program
+  multimeter.screen.program.key('f9', () => {
+    setPaused(! paused);
   });
 
   multimeter.addStatus(function () {

--- a/plugins/pause.js
+++ b/plugins/pause.js
@@ -1,5 +1,3 @@
-const blessed = require("blessed");
-
 const HELP_TEXT =
   "/pause   Pause the console output.\n" +
   "/unpause Resume the console output.";
@@ -13,26 +11,23 @@ module.exports = function(multimeter) {
     }
   });
 
-  let pausedMessage = blessed.box({
-    parent: multimeter.screen,
-    bottom: 1,
-    height: 1,
-    left: "center",
-    align: "center",
-    width: 20,
-    content: "***** PAUSED *****",
-    bold: true,
-    hidden: true,
+  multimeter.addStatus(function () {
+    if (paused) {
+      return 'PAUSED';
+    }
   });
 
+  function setPaused(value) {
+    paused = !! value;
+    multimeter.updateStatus();
+  }
+
   function commandPause() {
-    paused = true;
-    pausedMessage.show();
+    setPaused(true);
   }
 
   function commandUnpause() {
-    paused = false;
-    pausedMessage.hide();
+    setPaused(false);
   }
 
   multimeter.addCommand("pause", {

--- a/src/console.js
+++ b/src/console.js
@@ -25,6 +25,17 @@ module.exports = class Console extends blessed.element {
       style: { inverse: true },
     });
 
+    this.statusView = blessed.text({
+      parent: this.inputView,
+      width: 0,
+      right: 0,
+      align: 'right',
+      content: '',
+      bold: true,
+      bg: 'black',
+      fg: 'red',
+    });
+
     this.inputView.key("escape", (ch, key) => {
       this.emit("exit");
     });
@@ -57,7 +68,7 @@ module.exports = class Console extends blessed.element {
   clear() {
     this.outputView.setContent('');
   }
-  
+
   addLines(type, line, shard) {
     let event = { type, line, shard };
     this.emit("addLines", event);
@@ -83,6 +94,16 @@ module.exports = class Console extends blessed.element {
     }
 
     this.screen.render();
+  }
+
+  setStatus(text) {
+    if (text) {
+      this.statusView.content = '[' + text + ']';
+      this.statusView.width = null;
+    } else {
+      this.statusView.content = '';
+      this.statusView.width = 0;
+    }
   }
 
   log(line) {

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -16,6 +16,7 @@ const BUILTIN_PLUGINS = [
   "../plugins/watch",
   "../plugins/screeps_console.compat",
   "../plugins/html.js",
+  "../plugins/pause",
   "../plugins/log"
 ];
 

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -113,6 +113,7 @@ module.exports = class Multimeter extends EventEmitter {
     this.commands = {};
     this.cpuLimit = 1;
     this.memoryLimit = 2097152;
+    this.statusHandlers = [];
 
     this.addCommand("help", {
       description: 'List the available commands. Try "/help help".',
@@ -137,6 +138,7 @@ module.exports = class Multimeter extends EventEmitter {
         'If SHARD is a number, it will be prefixed with "shard", so "/shard 2" will set the shard to shard2.',
       handler: this.commandShard.bind(this),
     });
+
     this.addCommand("quit", {
       description: "Exit the program.",
       handler: this.commandQuit.bind(this),
@@ -285,6 +287,25 @@ module.exports = class Multimeter extends EventEmitter {
     } else {
       return [[], line];
     }
+  }
+
+  // Register a function to add a status indicator to the right of the input bar.
+  // Only one status indicator can be shown at a time, so the first one to return a status wins.
+  // Make sure important plugins are defined first (e.g. pause should come before filter).
+  // You should call updateStatus() whenever your plugin status changes.
+  addStatus(fn) {
+    this.statusHandlers.push(fn);
+  }
+
+  updateStatus(fn) {
+    for (let handler of this.statusHandlers) {
+      let status = handler();
+      if (status) {
+        this.console.setStatus(status);
+        return;
+      }
+    }
+    this.console.setStatus(null);
   }
 
   /// Register a slash-command. Config object looks like:

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -17,6 +17,7 @@ const BUILTIN_PLUGINS = [
   "../plugins/screeps_console.compat",
   "../plugins/html.js",
   "../plugins/pause",
+  "../plugins/filter",
   "../plugins/log"
 ];
 


### PR DESCRIPTION
Add commands to temporarily pause the console output. This is useful when you've got lots of debug output and you want to review it, or if you want to run a command and not have the output swamped by other logging (pausing only pauses the log output, not the command result output).