### PR TITLE
Add shard support to Watch plugin (Fixes #32)

### DIFF
--- a/plugins/watch.js
+++ b/plugins/watch.js
@@ -16,7 +16,7 @@ const HELP_TEXT_WATCH =
   "/watchshard SHARD   Set the shard used by the Watch plugin.\n" +
   "/watchshard         Show the current selected shard." +
   "\n" +
-  'If SHARD is a number, it will be prefixed with "shard", so "/shard 2" will set the shard to shard2.'
+  'If SHARD is a number, it will be prefixed with "shard", so "/wshard 2" will set the shard to shard2.'
   
 module.exports = function(multimeter) {
   if (!multimeter.config.watchShard) {

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -323,7 +323,7 @@ module.exports = class Multimeter extends EventEmitter {
         "Available commands:\n" +
           _.map(
             list,
-            cmd => "/" + _.padEnd(cmd.name, longest) + "  " + cmd.description,
+            cmd => "/" + _.padRight(cmd.name, longest) + "  " + cmd.description,
           ).join("\n"),
       );
     }
@@ -344,8 +344,10 @@ module.exports = class Multimeter extends EventEmitter {
         shard = 'shard' + shard;
       }
       this.shard = shard;
+	  this.config.shard = shard;
+    this.configManager.saveConfig();
     }
-    this.log("Shard: " + this.shard);
+    this.log("Command Shard: " + this.shard);
   }
 
   commandQuit() {


### PR DESCRIPTION
This fixes #32, however it does not expand the /shard command as suggested in that issue. I opted to create a secondary command /wshard in the Watch plugin to manage shard selection for the plugin. The functionality for the command is identical to the original /shard command on the user's end. 

My reasoning for this is to keep plugin territory separate from the core application while accomplishing what we needed. 

Upon /wshard's usage, it will also save the given shard to the config file under the name `watchShard`. I mirrored this functionality to the original /shard command, keeps these values updated.