### PR TITLE
Multiple shard support for watch plugin (continued from #36)

### DIFF
--- a/plugins/watch.js
+++ b/plugins/watch.js
@@ -16,7 +16,7 @@ const HELP_TEXT_WATCH =
   "/watchshard SHARD   Set the shard used by the Watch plugin.\n" +
   "/watchshard         Show the current selected shard." +
   "\n" +
-  'If SHARD is a number, it will be prefixed with "shard", so "/shard 2" will set the shard to shard2.'
+  'If SHARD is a number, it will be prefixed with "shard", so "/wshard 2" will set the shard to shard2.'
   
 module.exports = function(multimeter) {
   if (!multimeter.config.watchShard) {

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -344,8 +344,6 @@ module.exports = class Multimeter extends EventEmitter {
         shard = 'shard' + shard;
       }
       this.shard = shard;
-	  this.config.shard = shard;
-    this.configManager.saveConfig();
     }
     this.log("Command Shard: " + this.shard);
   }

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -323,7 +323,7 @@ module.exports = class Multimeter extends EventEmitter {
         "Available commands:\n" +
           _.map(
             list,
-            cmd => "/" + _.padEnd(cmd.name, longest) + "  " + cmd.description,
+            cmd => "/" + _.padRight(cmd.name, longest) + "  " + cmd.description,
           ).join("\n"),
       );
     }
@@ -344,8 +344,10 @@ module.exports = class Multimeter extends EventEmitter {
         shard = 'shard' + shard;
       }
       this.shard = shard;
+	  this.config.shard = shard;
+    this.configManager.saveConfig();
     }
-    this.log("Shard: " + this.shard);
+    this.log("Command Shard: " + this.shard);
   }
 
   commandQuit() {

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -323,7 +323,7 @@ module.exports = class Multimeter extends EventEmitter {
         "Available commands:\n" +
           _.map(
             list,
-            cmd => "/" + _.padRight(cmd.name, longest) + "  " + cmd.description,
+            cmd => "/" + _.padEnd(cmd.name, longest) + "  " + cmd.description,
           ).join("\n"),
       );
     }

--- a/src/nux.js
+++ b/src/nux.js
@@ -105,7 +105,7 @@ module.exports = function() {
       ),
     )
     .then(config =>
-      prompt(screen, "Enter shard name:", "shard0").then(shard =>
+      prompt(screen, "Enter the default shard name:", "shard0").then(shard =>
         Object.assign({ shard }, config),
       ),
     )


### PR DESCRIPTION
Continuing from the work by @InValidFire, this adds multiple shard support to the watch plugin.

- Removed config file auto-update for `/shard`, the shard in the config file is the "default" shard to use at startup
- `/watch` now changes the settings for the current shard as selected by `/shard`
- `/watch status` now shows status for all registered shards, one line per shard, prefixed with the shard name (we could consider implementing an option for a more compact column layout for this at some point)
- Drastically improved error messages and error handling in case `watch-client.js` is missing

I think this works quite well, and avoids the issues with separate shard state for the watch plugin.