### PR TITLE
Multiline input using bracketed paste mode (fixes #13)

### DIFF
--- a/plugins/alias.js
+++ b/plugins/alias.js
@@ -111,7 +111,7 @@ module.exports = function(multimeter) {
           _.map(
             matched,
             c =>
-              _.padRight(c, longest) +
+              _.padEnd(c, longest) +
               "  " +
               multimeter.commands[c.toLowerCase()].description,
           ).join("\n"),

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -159,12 +159,20 @@ module.exports = class Multimeter extends EventEmitter {
     });
 
     this.screen.program.key("C-c", () => {
-      process.exit(0);
+      this.emit('exit');
     });
 
     this.screen.program.key("C-l", () => {
       this.screen.alloc();
       this.screen.render();
+    });
+
+    // Enable bracketed paste mode
+    this.screen.program.setMode('?2004h');
+
+    this.on('exit', () => {
+      // Disable bracketed paste mode
+      this.screen.program.setMode('?2004l');
     });
 
     this.gauges = new Gauges({


### PR DESCRIPTION
Adds support for pasting multiline input using bracketed paste mode. Also added shift-enter so you can add line breaks manually in a similar way.