### PR TITLE
Html plugin parse result line

### DIFF
--- a/plugins/html.js
+++ b/plugins/html.js
@@ -2,7 +2,7 @@ const parse5 = require('parse5');
 
 module.exports = function(multimeter) {
   multimeter.console.on("addLines", function(event) {
-    if (event.type === "log") {
+    if (event.type === "log" || event.type === "result") {
       event.line = parseLogHtml(event.line);
       event.formatted = true;
     }

--- a/test/plugins/html.js
+++ b/test/plugins/html.js
@@ -11,9 +11,9 @@ let mmStub = {
 };
 HtmlPlugin(mmStub);
 
-function compare(input, expected) {
+function compare(input, expected, eventType = 'log') {
   let event = {
-    type: 'log',
+    type: eventType,
     line: input,
   };
   listener(event);
@@ -67,5 +67,13 @@ describe('html plugin', function () {
     compare('A < B and B > C', 'A < B and B > C');
     compare('foo < bar <span>C</span>', 'foo < bar C');
     compare('foo<<span>bar</span>', 'foo<bar');
+  });
+
+  it('should parse result line', function () {
+    compare(
+      'A<div style="color:red">B<span style="font-weight:bold">C</div>D',
+      'A{red-fg}B{bold}C{/bold}{/red-fg}D',
+      'result'
+    );
   });
 });


### PR DESCRIPTION
fix  #48 

Html plugin listen to `event.type === "result"` and test case.