### PR TITLE
allow using an environment variable as the token

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ configs:
     logFilename: 'multimeter.log'
 ```
 
+### Environment Variable
+You can also set `SCREEPS_TOKEN` as an environment variable instead of adding the token in the yaml file. If set, the token from the yaml file will take precedence over the environment variable.
+
+This can be useful if you want to commit your `.screeps.yaml` to a repo, but don't want your TOKEN exposed.
+
 ### Connecting to the official server
 
 You will need to create a [Screeps API token](http://docs.screeps.com/auth-tokens.html) and update the config as appropriate.

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -222,7 +222,7 @@ module.exports = class Multimeter extends EventEmitter {
 
     // TODO: Use ScreepsAPI.fromConfig instead?
     var opts = {};
-    opts.token = this.config.server.token;
+    opts.token = this.config.server.token || process.env.SCREEPS_TOKEN;
     opts.protocol = this.config.server.secure ? 'https' : 'http';
     if (this.config.server.host) opts.hostname = this.config.server.host;
     if (this.config.server.port) opts.port = this.config.server.port;
@@ -233,7 +233,7 @@ module.exports = class Multimeter extends EventEmitter {
     this.console.log(`Connecting to ${serverName} (${this.api.opts.url}) ...`);
 
     // We need to get a new token from the server if we don't already have one.
-    if (!this.config.server.token) {
+    if (!opts.token) {
       await this.api.auth(this.config.server.username, this.config.server.password);
     }
 


### PR DESCRIPTION
This PR adds support for an environment variable `SCREEPS_TOKEN`, so we can commit `.screeps.yaml` file safely to a git repo without exposing the TOKEN.

Got into this problem myself some days ago :sweat_smile: 