### PR TITLE
Server-specific log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Tags may be nested:
 
 ### Plugin: Logging
 
-The logging plugin allows you to log screeps output and error output to a file. To enable logging, add logging to your config file:
+The logging plugin allows you to log screeps output and error output to a file. To enable logging, set `logFilename` and/or `errorLogFilename` in your config file:
 
 ```
 configs:
@@ -175,7 +175,15 @@ configs:
     logFilename: "multimeter.log"
 ```
 
-To log errors to a separate file, add this to your multimeter config as well:
+`${server}` in the filename is replaced with the current server name from `.screeps.yaml` (the same name used with `--server` / `/server`). The log file is reopened when you switch servers:
+
+```
+configs:
+  multimeter:
+    logFilename: "multimeter-${server}.log"
+```
+
+To log errors to a separate file (or to log only errors), set `errorLogFilename`:
 
 ```
 configs:

--- a/plugins/log.js
+++ b/plugins/log.js
@@ -1,20 +1,67 @@
 const fs = require('fs');
 
-module.exports = function (multimeter) {
-    let log = multimeter.config.logFilename;
-    if (!log) return;
-    let errorLog = log || multimeter.config.errorLogFilename;
+function expandFilename(template, serverName) {
+    return template ? template.replace(/\$\{server\}/g, () => serverName) : null;
+}
 
-    const logFile = fs.createWriteStream(log, { flags: 'a' });
-    const errorLogFile = fs.createWriteStream(errorLog, { flags: 'a' });
+module.exports = function (multimeter) {
+    if (!multimeter.config.logFilename && !multimeter.config.errorLogFilename) {
+        return;
+    }
+
+    let logFile = null;
+    let errorLogFile = null;
+    let logPath = null;
+    let errorLogPath = null;
+
+    function openStreams() {
+        const serverName = multimeter.configManager.serverName;
+        const nextLogPath = expandFilename(multimeter.config.logFilename, serverName);
+        const nextErrorLogPath = expandFilename(multimeter.config.errorLogFilename, serverName);
+
+        if (nextLogPath === logPath && nextErrorLogPath === errorLogPath) {
+            return;
+        }
+
+        if (nextLogPath === logPath) {
+           // No need to reopen
+        } else if (nextLogPath) {
+            if (logFile) {
+                logFile.end();
+            }
+            logFile = fs.createWriteStream(nextLogPath, { flags: 'a' });
+            logPath = nextLogPath;
+        } else {
+            logFile = null;
+            logPath = null;
+        }
+
+        if (nextErrorLogPath && nextErrorLogPath === errorLogPath) {
+            // No need to reopen
+        } else if (nextErrorLogPath) {
+            if (errorLogFile) {
+                errorLogFile.end();
+            }
+            errorLogFile = fs.createWriteStream(nextErrorLogPath, { flags: 'a' });
+            errorLogPath = nextErrorLogPath;
+        } else {
+            errorLogFile = logFile;
+            errorLogPath = null;
+        }
+    }
+
+    openStreams();
+    multimeter.on('server', openStreams);
 
     multimeter.console.on('addLines', function (event) {
         const shard = event.shard ? `[${event.shard}] ` : '';
         const msg = new Date().toISOString() + ': ' + shard + event.line + '\n';
-        if (event.type === 'log' || event.type === 'result') {
+        if ((event.type === 'log' || event.type === 'result') && logFile) {
             logFile.write(msg);
-        } else if (event.type === 'error') {
+        } else if (event.type === 'error' && errorLogFile) {
             errorLogFile.write(msg);
         }
     });
 };
+
+module.exports.expandFilename = expandFilename;

--- a/src/multimeter.js
+++ b/src/multimeter.js
@@ -215,13 +215,17 @@ module.exports = class Multimeter extends EventEmitter {
 
     async connect(serverName) {
         serverName = serverName || this.configManager.serverName;
-        if (serverName !== this.configManager.serverName) {
+        const previousServer = this.configManager.serverName;
+        if (serverName !== previousServer) {
             await this.configManager.loadConfig(serverName);
             if (this.api) {
                 this.disconnect();
             }
         }
         this.config = this.configManager.config;
+        if (serverName !== previousServer) {
+            this.emit('server', serverName);
+        }
 
         this.console.log(`Connecting to ${serverName}...`);
         this.api = await ScreepsHttpClient.fromConfig(serverName);

--- a/test/plugins/log.js
+++ b/test/plugins/log.js
@@ -1,0 +1,186 @@
+const assert = require('assert');
+const EventEmitter = require('events');
+const fs = require('fs');
+const logPlugin = require('../../plugins/log');
+
+const { expandFilename } = logPlugin;
+
+function createMultimeter(opts) {
+    const mm = new EventEmitter();
+    mm.config = {
+        logFilename: opts.logFilename,
+        errorLogFilename: opts.errorLogFilename,
+    };
+    mm.configManager = {
+        serverName: opts.serverName || 'main',
+    };
+    mm.console = new EventEmitter();
+    return mm;
+}
+
+function mockStream(file) {
+    return {
+        path: file,
+        chunks: [],
+        ended: false,
+        write(data) {
+            this.chunks.push(data);
+            return true;
+        },
+        end() {
+            this.ended = true;
+        },
+    };
+}
+
+describe('log plugin', function () {
+    let originalCreateWriteStream;
+    let streams;
+
+    beforeEach(function () {
+        streams = [];
+        originalCreateWriteStream = fs.createWriteStream;
+        fs.createWriteStream = function (file) {
+            const stream = mockStream(file);
+            streams.push(stream);
+            return stream;
+        };
+    });
+
+    afterEach(function () {
+        fs.createWriteStream = originalCreateWriteStream;
+    });
+
+    describe('expandFilename', function () {
+        it('replaces ${server} with the server name', function () {
+            assert.equal(
+                expandFilename('multimeter-${server}.log', 'private'),
+                'multimeter-private.log',
+            );
+        });
+
+        it('leaves other filenames unchanged', function () {
+            assert.equal(
+                expandFilename('multimeter.log', 'main'),
+                'multimeter.log',
+            );
+        });
+
+        it('does not replace $server', function () {
+            assert.equal(
+                expandFilename('multimeter-$server.log', 'main'),
+                'multimeter-$server.log',
+            );
+        });
+    });
+
+    it('does nothing when no log filenames are set', function () {
+        logPlugin(createMultimeter({}));
+        assert.equal(streams.length, 0);
+    });
+
+    it('writes errors to the log file when errorLogFilename is unset', function () {
+        const mm = createMultimeter({ logFilename: 'multimeter.log' });
+        logPlugin(mm);
+        mm.console.emit('addLines', { type: 'error', line: 'boom' });
+        assert.equal(streams.length, 1);
+        assert.match(streams[0].chunks[0], /: boom\n$/);
+    });
+
+    it('writes log lines to the configured file', function () {
+        const mm = createMultimeter({ logFilename: 'multimeter.log' });
+        logPlugin(mm);
+        assert.equal(streams.length, 1);
+        assert.equal(streams[0].path, 'multimeter.log');
+
+        mm.console.emit('addLines', {
+            type: 'log',
+            line: 'hello',
+            shard: 'shard0',
+        });
+        assert.match(
+            streams[0].chunks[0],
+            /^\d{4}-.+: \[shard0\] hello\n$/,
+        );
+    });
+
+    it('expands ${server} when opening the log file', function () {
+        const mm = createMultimeter({
+            logFilename: 'multimeter-${server}.log',
+            serverName: 'season',
+        });
+        logPlugin(mm);
+        assert.equal(streams[0].path, 'multimeter-season.log');
+    });
+
+    it('reopens the log file when the server changes', function () {
+        const mm = createMultimeter({
+            logFilename: 'multimeter-${server}.log',
+            serverName: 'main',
+        });
+        logPlugin(mm);
+        mm.console.emit('addLines', { type: 'log', line: 'one' });
+
+        mm.configManager.serverName = 'ptr';
+        mm.emit('server', 'ptr');
+
+        assert.equal(streams[0].ended, true);
+        assert.equal(streams[1].path, 'multimeter-ptr.log');
+
+        mm.console.emit('addLines', { type: 'log', line: 'two' });
+        assert.equal(streams[0].chunks.length, 1);
+        assert.match(streams[1].chunks[0], /: two\n$/);
+    });
+
+    it('does not reopen a static log file on server switch', function () {
+        const mm = createMultimeter({ logFilename: 'multimeter.log' });
+        logPlugin(mm);
+        mm.configManager.serverName = 'ptr';
+        mm.emit('server', 'ptr');
+        assert.equal(streams.length, 1);
+        assert.equal(streams[0].ended, false);
+    });
+
+    it('writes errors to errorLogFilename when set', function () {
+        const mm = createMultimeter({
+            logFilename: 'multimeter.log',
+            errorLogFilename: 'errors.log',
+        });
+        logPlugin(mm);
+        assert.equal(streams.length, 2);
+        assert.equal(streams[0].path, 'multimeter.log');
+        assert.equal(streams[1].path, 'errors.log');
+
+        mm.console.emit('addLines', { type: 'error', line: 'boom' });
+        assert.equal(streams[0].chunks.length, 0);
+        assert.match(streams[1].chunks[0], /: boom\n$/);
+    });
+
+    it('logs only errors when only errorLogFilename is set', function () {
+        const mm = createMultimeter({ errorLogFilename: 'errors.log' });
+        logPlugin(mm);
+        assert.equal(streams.length, 1);
+        assert.equal(streams[0].path, 'errors.log');
+
+        mm.console.emit('addLines', { type: 'log', line: 'hello' });
+        mm.console.emit('addLines', { type: 'error', line: 'boom' });
+        assert.equal(streams[0].chunks.length, 1);
+        assert.match(streams[0].chunks[0], /: boom\n$/);
+    });
+
+    it('expands ${server} in errorLogFilename on server switch', function () {
+        const mm = createMultimeter({
+            logFilename: 'multimeter-${server}.log',
+            errorLogFilename: 'errors-${server}.log',
+            serverName: 'main',
+        });
+        logPlugin(mm);
+        mm.configManager.serverName = 'ptr';
+        mm.emit('server', 'ptr');
+
+        assert.equal(streams[0].ended, true);
+        assert.equal(streams[1].ended, true);
+        assert.equal(streams[2].path, 'multimeter-ptr.log');
+        assert.equal(streams[3].path, 'errors-ptr.log');
+    });
+});


### PR DESCRIPTION
This makes logFilename a template string, with a new marker `${server}`, that makes it so multimeter changes log file when switching servers.

Also fixes errorLogFilename; we were defaulting to logFilename previously, so setting it made no difference.